### PR TITLE
Revert VS Code automatic changes to Jupyter metadata

### DIFF
--- a/Search/arxiv_api.ipynb
+++ b/Search/arxiv_api.ipynb
@@ -772,8 +772,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "name": "python379jvsc74a57bd08fadb302ac1b81829d9f5e927356da45064af985abb663ca893ff1a2f2419c8b",
-   "display_name": "Python 3.7.9 64-bit ('3.7.9': pyenv)"
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -785,7 +786,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Changes

Reverts changes automatically made to Jupyter metadata by VS Code as part of https://github.com/EPS-Libraries-Berkeley/volt/pull/162.

+ Use language version Python 3.7.6
+ Use the kernel named `python3`

# Motivation

Deploy https://github.com/EPS-Libraries-Berkeley/volt/pull/162!

That PR broke the GitHub Pages build. I inadvertently changed the specified Jupyter kernel (well, my editor did it automatically) and I didn't catch it before opening the PR. The build system doesn't have the same Jupyter kernel as my local system (`python379jvsc74a57bd08fadb302ac1b81829d9f5e927356da45064af985abb663ca893ff1a2f2419c8b`).

# Testing

I made these changes manually by reading my last PR's diff; this PR reverses these changes: https://github.com/EPS-Libraries-Berkeley/volt/pull/162/files#diff-ddd0a2f634445661e197c9ab25961ed0875742cdc9639ccfd09ce6783867cdf0L5634-L5653

~I'll take a shot at getting the GitHub Actions workflow running in my repo to test this. Watch this space!~

Edit: the GitHub Actions build succeeds: https://github.com/lukasschwab/volt/runs/2416253187?check_suite_focus=true 🎉 

Cheers